### PR TITLE
feat: add support for Font Awesome Pro

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -17,19 +17,7 @@ for STYLE in "${STYLES[@]}"; do
         mkdir "${RESOURCES_DIR}"
     fi
 
-    for FILE in "${ICONS_DIR}/"*.svg; do
-      FILENAME=${FILE##*/}
-
-      if [ "$FILENAME" == ".gitignore" ]; then
-        break
-      fi
-
-      # Compile icons...
-      cp "${FILE}" "${RESOURCES_DIR}/${FILENAME}"
-
-      CLASS='<svg fill="currentColor"'
-      sed -i "s/<svg/${CLASS}/" "${RESOURCES_DIR}/${FILENAME}"
-    done
+    php -r "require __DIR__.'/src/Actions/CompileSvgsAction.php'; (new \OwenVoke\BladeFontAwesome\Actions\CompileSvgsAction('${ICONS_DIR}', '${RESOURCES_DIR}'))->execute();"
 done
 
 echo "All done!"

--- a/src/Actions/CompileSvgsAction.php
+++ b/src/Actions/CompileSvgsAction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OwenVoke\BladeFontAwesome\Actions;
+
+use DirectoryIterator;
+
+class CompileSvgsAction
+{
+    /** @var string */
+    private $svgDirectory;
+    /** @var string */
+    private $svgOutputDirectory;
+
+    public function __construct(string $svgDirectory, string $svgOutputDirectory)
+    {
+        $this->svgDirectory = $svgDirectory;
+        $this->svgOutputDirectory = $svgOutputDirectory;
+    }
+
+    public function execute(): void
+    {
+        foreach (new DirectoryIterator($this->svgDirectory) as $svg) {
+            if (! $svg->isFile() || $svg->getExtension() !== 'svg') {
+                continue;
+            }
+
+            /** @var string $svgContent */
+            $svgContent = file_get_contents($svg->getPathname());
+            $svgContent = str_replace('<svg ', '<svg fill="currentColor" ', $svgContent);
+
+            file_put_contents("{$this->svgOutputDirectory}/{$svg->getFilename()}", $svgContent);
+        }
+    }
+}

--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OwenVoke\BladeFontAwesome;
 
 use BladeUI\Icons\Factory;
+use OwenVoke\BladeFontAwesome\Commands\SyncProIconsCommand;
 use Illuminate\Support\ServiceProvider;
 
 final class BladeFontAwesomeServiceProvider extends ServiceProvider
@@ -16,6 +17,12 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->callAfterResolving(Factory::class, function (Factory $factory) {
+            if (is_dir($proIconsPath = resource_path('icons/blade-fontawesome'))) {
+                $this->registerProIcons($factory, $proIconsPath);
+
+                return;
+            }
+
             $factory->add('fontawesome-brands', [
                 self::PATH => __DIR__.'/../resources/svg/brands',
                 self::PREFIX => 'fab',
@@ -39,6 +46,38 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../resources/svg' => public_path('vendor/blade-fontawesome'),
             ], 'blade-fontawesome');
+
+            $this->commands([
+                SyncProIconsCommand::class,
+            ]);
         }
+    }
+
+    private function registerProIcons(Factory $factory, string $proIconsPath): void
+    {
+        $factory->add('fontawesome-brands', [
+            self::PATH => "{$proIconsPath}/brands",
+            self::PREFIX => 'fab',
+        ]);
+
+        $factory->add('fontawesome-duotone', [
+            self::PATH => "{$proIconsPath}/duotone",
+            self::PREFIX => 'fad',
+        ]);
+
+        $factory->add('fontawesome-light', [
+            self::PATH => "{$proIconsPath}/light",
+            self::PREFIX => 'fal',
+        ]);
+
+        $factory->add('fontawesome-regular', [
+            self::PATH => "{$proIconsPath}/regular",
+            self::PREFIX => 'far',
+        ]);
+
+        $factory->add('fontawesome-solid', [
+            self::PATH => "{$proIconsPath}/solid",
+            self::PREFIX => 'fas',
+        ]);
     }
 }

--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace OwenVoke\BladeFontAwesome;
 
 use BladeUI\Icons\Factory;
-use OwenVoke\BladeFontAwesome\Commands\SyncProIconsCommand;
 use Illuminate\Support\ServiceProvider;
+use OwenVoke\BladeFontAwesome\Commands\SyncProIconsCommand;
 
 final class BladeFontAwesomeServiceProvider extends ServiceProvider
 {

--- a/src/Commands/SyncProIconsCommand.php
+++ b/src/Commands/SyncProIconsCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OwenVoke\BladeFontAwesome\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+final class SyncProIconsCommand extends Command
+{
+    protected $signature = 'blade-fontawesome:sync-pro
+                          {directory? : The root directory containing the npm Font Awesome fonts}';
+
+    protected $description = 'Synchronise Font Awesome Pro icons from npm';
+
+    /** @var string|null */
+    private $directory;
+
+    public function handle(): ?int
+    {
+        /** @phpstan-ignore-next-line */
+        $this->directory = (string) ($this->argument('directory') ?? base_path());
+
+        $fullSourcePath = "{$this->directory}/node_modules/@fortawesome/fontawesome-pro/svgs";
+
+        if (!is_dir($fullSourcePath)) {
+            $this->warn("Unable to find Font Awesome Pro SVGs in '{$this->directory}'");
+
+            return 1;
+        }
+
+        $destinationPath = resource_path('icons/blade-fontawesome');
+
+        if (!File::copyDirectory($fullSourcePath, $destinationPath)) {
+            $this->warn("Unable to find Font Awesome Pro SVGs in '{$this->directory}'");
+
+            return 1;
+        }
+
+        $this->info("Successfully updated Font Awesome Pro SVGs");
+        $this->line("- From: {$fullSourcePath}");
+        $this->line("- To: {$destinationPath}");
+
+        return 0;
+    }
+}

--- a/src/Commands/SyncProIconsCommand.php
+++ b/src/Commands/SyncProIconsCommand.php
@@ -2,8 +2,10 @@
 
 namespace OwenVoke\BladeFontAwesome\Commands;
 
+use DirectoryIterator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use OwenVoke\BladeFontAwesome\Actions\CompileSvgsAction;
 
 final class SyncProIconsCommand extends Command
 {
@@ -36,9 +38,23 @@ final class SyncProIconsCommand extends Command
             return 1;
         }
 
+        $sets = [];
+
+        foreach (new DirectoryIterator($destinationPath) as $directory) {
+            if ($directory->isDot() || ! $directory->isDir()) {
+                continue;
+            }
+
+            (new CompileSvgsAction($directory->getPathname(), $directory->getPathname()))->execute();
+
+            $sets[] = $directory->getBasename();
+        }
+
         $this->info('Successfully updated Font Awesome Pro SVGs');
         $this->line("- From: {$fullSourcePath}");
         $this->line("- To: {$destinationPath}");
+
+        $this->line("\nSets copied: ".implode(', ', $sets));
 
         return 0;
     }

--- a/src/Commands/SyncProIconsCommand.php
+++ b/src/Commands/SyncProIconsCommand.php
@@ -22,7 +22,7 @@ final class SyncProIconsCommand extends Command
 
         $fullSourcePath = "{$this->directory}/node_modules/@fortawesome/fontawesome-pro/svgs";
 
-        if (!is_dir($fullSourcePath)) {
+        if (! is_dir($fullSourcePath)) {
             $this->warn("Unable to find Font Awesome Pro SVGs in '{$this->directory}'");
 
             return 1;
@@ -30,13 +30,13 @@ final class SyncProIconsCommand extends Command
 
         $destinationPath = resource_path('icons/blade-fontawesome');
 
-        if (!File::copyDirectory($fullSourcePath, $destinationPath)) {
+        if (! File::copyDirectory($fullSourcePath, $destinationPath)) {
             $this->warn("Unable to find Font Awesome Pro SVGs in '{$this->directory}'");
 
             return 1;
         }
 
-        $this->info("Successfully updated Font Awesome Pro SVGs");
+        $this->info('Successfully updated Font Awesome Pro SVGs');
         $this->line("- From: {$fullSourcePath}");
         $this->line("- To: {$destinationPath}");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This adds support for using Font Awesome Pro icons.

1. Install Font Awesome Pro as usual through npm (`npm i --save @fortawesome/fontawesome-pro`)
1. Run the "sync" command (`php artisan blade-fontawesome:sync-pro`)
1. Profit 😉

Check out #3 for more information.

---

**Things to do:**

- ~~Update `bin/compile.sh` to work with pro icons, or probably add it as a PHP script instead that can be run for any directory of SVGs (that way it can be integrated into the sync command).~~

---

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/.github/CONTRIBUTING.md)** document.

Closes #3