### PR TITLE
feat: add config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Via Composer
 $ composer require owenvoke/blade-fontawesome
 ```
 
+## Configuration
+
+Blade Font Awesome also offers the ability to use features from Blade Icons like default classes, default attributes, etc. If you'd like to configure these, publish the `blade-fontawesome.php` config file:
+
+```bash
+php artisan vendor:publish --tag=blade-fontawesome-config
+```
+
 ## Usage
 
 Icons can be used a self-closing Blade components which will be compiled to SVG icons:

--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -1,0 +1,92 @@
+<?php
+
+return [
+
+    'brands' => [
+
+        'prefix' => 'fab',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'regular' => [
+
+        'prefix' => 'far',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'solid' => [
+
+        'prefix' => 'fas',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    /*
+    |-----------------------------------------------------------------
+    | Pro Icon Sets
+    |-----------------------------------------------------------------
+    |
+    | The following configuration values are for configuring the
+    | icon sets available as part of Font Awesome Pro.
+    |
+    | If you are not using Font Awesome Pro, this can be removed.
+    |
+    */
+
+    'duotone' => [
+
+        'prefix' => 'fad',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'light' => [
+
+        'prefix' => 'fal',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This implements a configuration file as suggested by Dries Vints, allowing the ability to use Blade Icons features like default classes, default attributes, etc.

I have excluded most of the comments from Dries' original PRs as there are 5 icon sets which would cause the configuration file to be bloated with duplicate comments.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/.github/CONTRIBUTING.md)** document.
