### PR TITLE
Load icons from custom directory.

### DIFF
--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -55,12 +55,42 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
 
     private function registerProIcons(Factory $factory, string $proIconsPath, Repository $config): void
     {
-        $factory->add('fontawesome-brands', array_merge(['path' => "{$proIconsPath}/brands"], $config->get('blade-fontawesome.brands', [])));
-        $factory->add('fontawesome-regular', array_merge(['path' => "{$proIconsPath}/regular"], $config->get('blade-fontawesome.regular', [])));
-        $factory->add('fontawesome-solid', array_merge(['path' => "{$proIconsPath}/solid"], $config->get('blade-fontawesome.solid', [])));
+        $factory->add('fontawesome-brands', array_merge(
+            [
+                'path' => "{$proIconsPath}/brands",
+                'paths' => ["{$proIconsPath}/brands"]
+            ],
+            $config->get('blade-fontawesome.brands', [])
+        ));
+        $factory->add('fontawesome-regular', array_merge(
+            [
+                'path' => "{$proIconsPath}/regular",
+                'paths' => ["{$proIconsPath}/regular"]
+            ],
+            $config->get('blade-fontawesome.regular', [])
+        ));
+        $factory->add('fontawesome-solid', array_merge(
+            [
+                'path' => "{$proIconsPath}/solid",
+                'paths' => ["{$proIconsPath}/solid"]
+            ],
+            $config->get('blade-fontawesome.solid', [])
+        ));
 
         // Pro icon sets
-        $factory->add('fontawesome-light', array_merge(['path' => "{$proIconsPath}/light"], $config->get('blade-fontawesome.light', [])));
-        $factory->add('fontawesome-duotone', array_merge(['path' => "{$proIconsPath}/duotone"], $config->get('blade-fontawesome.duotone', [])));
+        $factory->add('fontawesome-light', array_merge(
+            [
+                'path' => "{$proIconsPath}/light",
+                'paths' => ["{$proIconsPath}/light"]
+            ],
+            $config->get('blade-fontawesome.light', [])
+        ));
+        $factory->add('fontawesome-duotone', array_merge(
+            [
+                'path' => "{$proIconsPath}/duotone",
+                'paths' => ["{$proIconsPath}/duotone"]
+            ],
+            $config->get('blade-fontawesome.duotone', [])
+        ));
     }
 }


### PR DESCRIPTION
Currently if your icons are located in directory other that `blade-fontawesome`, Factory will throw an error complaining that "path" for a set does not exist. This happens because BladeUIKit package creates "paths" for sets the first time it create Factory. Since this package hooks up to BladeUIKit when its Factory is already instantiated "paths" key for icon sets is not filled.

Ideally, I'd look to update BladeUIKit Factory itself, but it won't hurt to manually sets paths in this library.

...

- [ ] I have read the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/.github/CONTRIBUTING.md)** document.
