### PR TITLE
Update CompileSvgsAction.php

### DIFF
--- a/src/Actions/CompileSvgsAction.php
+++ b/src/Actions/CompileSvgsAction.php
@@ -26,10 +26,17 @@ class CompileSvgsAction
             }
 
             /** @var string $svgContent */
+            /** RuntimeExceptions added to handle (potential) errors */
             $svgContent = file_get_contents($svg->getPathname());
+            if ($svgContent === false) {
+                throw new \RuntimeException("Failed to read SVG file: {$svg->getPathname()}");
+            }
             $svgContent = str_replace('<svg ', '<svg fill="currentColor" ', $svgContent);
 
-            file_put_contents("{$this->svgOutputDirectory}/{$svg->getFilename()}", $svgContent);
+            $outputFile = "{$this->svgOutputDirectory}/{$svg->getFilename()}";
+            if (file_put_contents($outputFile, $svgContent) === false) {
+                throw new \RuntimeException("Failed to write SVG file: $outputFile");
+            }
         }
     }
 }


### PR DESCRIPTION
RuntimeExceptions added to handle (potential) errors in the read/write of SVGs.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/.github/CONTRIBUTING.md)** document.
