### PR TITLE
Add sharp icons and kits icons

### DIFF
--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -149,4 +149,31 @@ return [
 
     ],
 
+    /*
+    |-----------------------------------------------------------------
+    | Pro Icon Kits
+    |-----------------------------------------------------------------
+    |
+    | The following configuration values are for configuring the
+    | icon sets available as part of Font Awesome Pro.
+    |
+    | If you are not using Font Awesome Pro, this can be removed.
+    |
+    */
+
+    'custom' => [
+
+        'prefix' => 'fak',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
 ];

--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -104,9 +104,39 @@ return [
 
     ],
 
-    'sharp' => [
+    'sharp-light' => [
 
-        'prefix' => 'fash',
+        'prefix' => 'fal-sharp',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'sharp-regular' => [
+
+        'prefix' => 'far-sharp',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'sharp-solid' => [
+
+        'prefix' => 'fas-sharp',
 
         'fallback' => '',
 

--- a/src/Actions/CompileSvgsAction.php
+++ b/src/Actions/CompileSvgsAction.php
@@ -30,6 +30,7 @@ class CompileSvgsAction
             /** @var string $svgContent */
             $svgContent = file_get_contents($svg->getPathname());
             $svgContent = str_replace('<svg ', '<svg fill="currentColor" ', $svgContent);
+            $svgContent = str_replace('height="1em" ', ' ', $svgContent);
 
             file_put_contents("{$this->svgOutputDirectory}/{$svg->getFilename()}", $svgContent);
         }

--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -67,6 +67,9 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
         $factory->add('fontawesome-sharp-light', array_merge(['path' => "{$proIconsPath}/sharp-light"], $config->get('blade-fontawesome.sharp-light', [])));
         $factory->add('fontawesome-sharp-regular', array_merge(['path' => "{$proIconsPath}/sharp-regular"], $config->get('blade-fontawesome.sharp-regular', [])));
         $factory->add('fontawesome-sharp-solid', array_merge(['path' => "{$proIconsPath}/sharp-solid"], $config->get('blade-fontawesome.sharp-solid', [])));
+
+        if (is_dir("{$proIconsPath}/custom")) {
+            $factory->add('fontawesome-custom', array_merge(['path' => "{$proIconsPath}/custom"], $config->get('blade-fontawesome.custom', [])));
         }
     }
 }

--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -64,8 +64,9 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
         $factory->add('fontawesome-duotone', array_merge(['path' => "{$proIconsPath}/duotone"], $config->get('blade-fontawesome.duotone', [])));
         $factory->add('fontawesome-thin', array_merge(['path' => "{$proIconsPath}/thin"], $config->get('blade-fontawesome.thin', [])));
 
-        if (is_dir("{$proIconsPath}/sharp")) {
-            $factory->add('fontawesome-sharp', array_merge(['path' => "{$proIconsPath}/sharp"], $config->get('blade-fontawesome.sharp', [])));
+        $factory->add('fontawesome-sharp-light', array_merge(['path' => "{$proIconsPath}/sharp-light"], $config->get('blade-fontawesome.sharp-light', [])));
+        $factory->add('fontawesome-sharp-regular', array_merge(['path' => "{$proIconsPath}/sharp-regular"], $config->get('blade-fontawesome.sharp-regular', [])));
+        $factory->add('fontawesome-sharp-solid', array_merge(['path' => "{$proIconsPath}/sharp-solid"], $config->get('blade-fontawesome.sharp-solid', [])));
         }
     }
 }


### PR DESCRIPTION
## Summary

* **New Configuration for Enhanced Icons**
A new setting has been added to the system which allows for sharper, more detailed display of icons. This is done through a file named `config/blade-fontawesome.php`.

* **Adjustments to SVG Image Display**
We've made some tweaks in the `CompileSvgsAction.php` file that affect how SVG (Scalable Vector Graphics) images are presented. They now have a standardized height which improves their uniformity and overall look.

* **Better Support for Icons and Their Variations**
The `BladeFontAwesomeServiceProvider.php` file has been updated to include more varieties of the popular FontAwesome icons and also support for custom icons, giving you more flexibility and choice in icon usage.

