### PR TITLE
Remove the dashes from config prefixes

### DIFF
--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -106,7 +106,7 @@ return [
 
     'sharp-light' => [
 
-        'prefix' => 'fal-sharp',
+        'prefix' => 'falsharp',
 
         'fallback' => '',
 
@@ -121,7 +121,7 @@ return [
 
     'sharp-regular' => [
 
-        'prefix' => 'far-sharp',
+        'prefix' => 'farsharp',
 
         'fallback' => '',
 
@@ -136,7 +136,7 @@ return [
 
     'sharp-solid' => [
 
-        'prefix' => 'fas-sharp',
+        'prefix' => 'fassharp',
 
         'fallback' => '',
 
@@ -151,7 +151,7 @@ return [
 
     'sharp-thin' => [
 
-        'prefix' => 'fat-sharp',
+        'prefix' => 'fatsharp',
 
         'fallback' => '',
 


### PR DESCRIPTION
This PR removes the dashes (-) from the prefixes in the config. When you attempt to use the "xxx-sharp" svg an error is encountered.

The blade-ui component [documentation ](https://github.com/blade-ui-kit/blade-icons?tab=readme-ov-file#prefixing-icons)states:

_It's also important to note that icon prefixes cannot contain dashes (-) as this is the delimiter which we use to split it from the rest of the icon name._
