### PR TITLE
Support Font Awesome Kits (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,21 @@ php artisan blade-fontawesome:sync-icons --pro
 
 Blade Font Awesome will then automatically detect and use the pro icons under the `resources/icons/blade-fontawesome` path.
 
-Because of the sheer number of icons, a small performance hit can be seen when using Pro icons. If you'd like to mitigate this, you can cache the icons. To do this, run the following Artisan command:
+### Font Awesome Kits
+
+Blade Font Awesome supports the use of the npm kits via the `--kit` option.
+
+To use a configured kit, [Font Awesome docs installing kits](https://docs.fontawesome.com/web/setup/packages#kit-package) using `npm install --save '@awesome.me/kit-KIT_CODE@latest'`, and then run the following Artisan command to add the icons to your `resources` path.
+
+```shell
+php artisan blade-fontawesome:sync-icons --kit=KIT_CODE
+```
+
+Blade Font Awesome will then use the icons from the kit to populate the `resources/icons/blade-fontawesome` directory.
+
+### Caching
+
+Because of the sheer number of icons, a small performance hit can be seen when using *pro or kit-supplied* icons. If you'd like to mitigate this, you can cache the icons. To do this, run the following Artisan command:
 
 ```shell
 php artisan icons:cache

--- a/src/Commands/SyncIconsCommand.php
+++ b/src/Commands/SyncIconsCommand.php
@@ -10,7 +10,7 @@ use OwenVoke\BladeFontAwesome\Actions\CompileSvgsAction;
 final class SyncIconsCommand extends Command
 {
     protected $signature = 'blade-fontawesome:sync-icons
-                          {directory? : The root directory containing the npm Font Awesome fonts}
+                          {directory? : The root directory containing the node_modules directory}
                           {--free : Use the fontawesome-free npm package}
                           {--pro : Use the fontawesome-pro npm package}
                           {--kit= : The Font Awesome kit id to use (these can be free or pro)}';
@@ -53,17 +53,17 @@ final class SyncIconsCommand extends Command
         }
 
         if (! is_dir($fullSourcePath)) {
-            $this->warn("Unable to find Font Awesome SVGs in '{$baseDirectory}'");
+            $this->warn("Unable to find Font Awesome SVGs in '{$fullSourcePath}'");
 
-            return 1;
+            return self::FAILURE;
         }
 
         $destinationPath = resource_path('icons/blade-fontawesome');
 
         if (! File::copyDirectory($fullSourcePath, $destinationPath)) {
-            $this->warn("Unable to find Font Awesome SVGs in '{$baseDirectory}'");
+            $this->warn("Unable to copy Font Awesome SVGs from '{$fullSourcePath}' to '{$destinationPath}'");
 
-            return 1;
+            return self::FAILURE;
         }
 
         $sets = [];
@@ -84,6 +84,6 @@ final class SyncIconsCommand extends Command
 
         $this->line("\nSets copied: ".implode(', ', $sets));
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/SyncIconsCommand.php
+++ b/src/Commands/SyncIconsCommand.php
@@ -12,7 +12,8 @@ final class SyncIconsCommand extends Command
     protected $signature = 'blade-fontawesome:sync-icons
                           {directory? : The root directory containing the npm Font Awesome fonts}
                           {--free : Use the fontawesome-free npm package}
-                          {--pro : Use the fontawesome-pro npm package}';
+                          {--pro : Use the fontawesome-pro npm package}
+                          {--kit= : The Font Awesome kit id to use (these can be free or pro)}';
 
     protected $description = 'Synchronise Font Awesome icons from npm';
 
@@ -34,6 +35,16 @@ final class SyncIconsCommand extends Command
             $fullSourcePath = $proSourcePath;
         } elseif ($this->option('free')) {
             $fullSourcePath = $freeSourcePath;
+        } elseif ($this->hasOption('kit')) {
+            $kitId = $this->option('kit');
+
+            if (! $kitId) {
+                $this->warn('You must provide a kit id when using the --kit option');
+
+                return self::FAILURE;
+            }
+
+            $fullSourcePath = "{$baseDirectory}/node_modules/@awesome.me/kit-{$kitId}/icons/svgs";
         } else {
             $fullSourcePath = collect([
                 $proSourcePath,

--- a/src/Commands/SyncIconsCommand.php
+++ b/src/Commands/SyncIconsCommand.php
@@ -38,7 +38,7 @@ final class SyncIconsCommand extends Command
         } elseif ($this->hasOption('kit')) {
             $kitId = $this->option('kit');
 
-            if (! $kitId) {
+            if (! is_string($kitId) || empty($kitId)) {
                 $this->warn('You must provide a kit id when using the --kit option');
 
                 return self::FAILURE;


### PR DESCRIPTION
Alters the `blade-fontawesome:sync-icons` command to have an option, `kit` providing a kit-code from the [Font Awesome docs regarding package managers](https://docs.fontawesome.com/web/setup/packages).

### Related to:
- Closes https://github.com/owenvoke/blade-fontawesome/issues/79