### PR TITLE
feat: add colon prefix for sharp icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ And even use inline styles:
 - Duotone (`fad`)
 - Light (`fal`)
 - Thin (`fat`)
-- Sharp Regular (`far-sharp`)
-- Sharp Light (`fal-sharp`)
-- Sharp Solid (`fas-sharp`)
+- Sharp Regular (`far:sharp`)
+- Sharp Light (`fal:sharp`)
+- Sharp Solid (`fas:sharp`)
+- Sharp Thin (`fat:sharp`)
 - Custom Kit Icons (`fak`)
 
 ### Raw SVG Icons

--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -106,7 +106,7 @@ return [
 
     'sharp-light' => [
 
-        'prefix' => 'falsharp',
+        'prefix' => 'fal:sharp',
 
         'fallback' => '',
 
@@ -121,7 +121,7 @@ return [
 
     'sharp-regular' => [
 
-        'prefix' => 'farsharp',
+        'prefix' => 'far:sharp',
 
         'fallback' => '',
 
@@ -136,7 +136,7 @@ return [
 
     'sharp-solid' => [
 
-        'prefix' => 'fassharp',
+        'prefix' => 'fas:sharp',
 
         'fallback' => '',
 
@@ -151,7 +151,7 @@ return [
 
     'sharp-thin' => [
 
-        'prefix' => 'fatsharp',
+        'prefix' => 'fat:sharp',
 
         'fallback' => '',
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I just think if we can have some sort of separator in the prefix, it would be much cleaner. 🤷🏻

Please check the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/CONTRIBUTING.md)** document for more information.
