### PR TITLE
Add missing kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ And even use inline styles:
 **Pro Icon Sets**
 
 - Duotone (`fad`)
+- Duotone Regular (`fad:regular`)
+- Duotone Light (`fad:light`)
+- Duotone Thin (`fad:thin`)
 - Light (`fal`)
 - Thin (`fat`)
 - Sharp Regular (`far:sharp`)
@@ -80,6 +83,9 @@ And even use inline styles:
 - Sharp Solid (`fas:sharp`)
 - Sharp Thin (`fat:sharp`)
 - Sharp Duotone (`fad:sharp`)
+- Sharp Duotone Regular (`fasd:regular`)
+- Sharp Duotone Light (`fasd:light`)
+- Sharp Duotone Thin (`fasd:thin`)
 - Custom Kit Icons (`fak`)
 
 ### Raw SVG Icons

--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -74,6 +74,51 @@ return [
 
     ],
 
+    'duotone-regular' => [
+
+        'prefix' => 'fad:regular',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'duotone-light' => [
+
+        'prefix' => 'fad:light',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'duotone-thin' => [
+
+        'prefix' => 'fad:thin',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
     'light' => [
 
         'prefix' => 'fal',
@@ -152,6 +197,51 @@ return [
     'sharp-duotone-solid' => [
 
         'prefix' => 'fad:sharp',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'sharp-duotone-regular' => [
+
+        'prefix' => 'fasd:regular',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'sharp-duotone-light' => [
+
+        'prefix' => 'fasd:light',
+
+        'fallback' => '',
+
+        'class' => '',
+
+        'attributes' => [
+            // 'width' => 50,
+            // 'height' => 50,
+        ],
+
+    ],
+
+    'sharp-duotone-thin' => [
+
+        'prefix' => 'fasd:thin',
 
         'fallback' => '',
 

--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -71,6 +71,9 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
         // Pro icon sets
         $addProIconSet('light');
         $addProIconSet('duotone');
+        $addProIconSet('duotone-regular');
+        $addProIconSet('duotone-light');
+        $addProIconSet('duotone-thin');
         $addProIconSet('thin');
 
         // Sharp icon sets
@@ -78,6 +81,9 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
         $addProIconSet('sharp-regular');
         $addProIconSet('sharp-solid');
         $addProIconSet('sharp-duotone-solid');
+        $addProIconSet('sharp-duotone-regular');
+        $addProIconSet('sharp-duotone-light');
+        $addProIconSet('sharp-duotone-thin');
         $addProIconSet('sharp-thin');
 
         // Custom icon sets


### PR DESCRIPTION
Hello,

This PR adds some missing kits from Fontawesome Pro:

- Duotone Regular (`fad:regular`)
- Duotone Light (`fad:light`)
- Duotone Thin (`fad:thin`)
- Sharp Duotone Regular (`fasd:regular`)
- Sharp Duotone Light (`fasd:light`)
- Sharp Duotone Thin (`fasd:thin`)
