### PR TITLE
Correct custom icons path

### DIFF
--- a/config/blade-fontawesome.php
+++ b/config/blade-fontawesome.php
@@ -191,7 +191,7 @@ return [
     |
     */
 
-    'custom' => [
+    'custom-icons' => [
 
         'prefix' => 'fak',
 

--- a/src/BladeFontAwesomeServiceProvider.php
+++ b/src/BladeFontAwesomeServiceProvider.php
@@ -81,6 +81,6 @@ final class BladeFontAwesomeServiceProvider extends ServiceProvider
         $addProIconSet('sharp-thin');
 
         // Custom icon sets
-        $addProIconSet('custom');
+        $addProIconSet('custom-icons');
     }
 }


### PR DESCRIPTION
Custom kit icons are exported to `/custom-icons` instead of `/custom`, but `/custom` is used by the library to load custom icons. This PR makes sure `/custom-icons` is used instead of `/custom`.

---

When I ran the following command, all custom icons were exported to `resources/icons/blade-fontawesome/custom-icons`:
`php artisan blade-fontawesome:sync-icons --kit=<id>`

When I then tried to load an icon like this: `<x-fak-squares />`, I got this error: `Unable to locate a class or view for component [fak-squares].`