### PR TITLE
chore(deps): drop support for older dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,16 +4,16 @@
     "description": "A package to easily make use of Font Awesome in your Laravel Blade views",
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.4",
         "blade-ui-kit/blade-icons": "^1.5",
-        "illuminate/support": "^10.34|^11.0|^12.0"
+        "illuminate/support": "^12.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.13",
-        "orchestra/testbench": "^8.12|^9.0|^10.0",
-        "pestphp/pest": "^2.26|^3.7",
-        "phpstan/phpstan": "^1.10|^2.1",
-        "symfony/var-dumper": "^6.3|^7.2"
+        "laravel/pint": "^1.25",
+        "orchestra/testbench": "^10.6",
+        "pestphp/pest": "^4.1",
+        "phpstan/phpstan": "^2.1",
+        "symfony/var-dumper": "^7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This updates to Pest 4.x, drops support for Laravel `<12.x`, and updates other dependencies.

Please check the **[CONTRIBUTING](https://github.com/owenvoke/blade-fontawesome/blob/main/CONTRIBUTING.md)** document for more information.
